### PR TITLE
Add AnalogGyro as a gyro option

### DIFF
--- a/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
@@ -20,6 +20,8 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.interfaces.Gyro;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 
@@ -118,6 +120,9 @@ public class Robot extends TimedRobot {
     // must be negated because getAngle returns a clockwise positive angle
     % if gyro == "ADXRS450":
     Gyro gyro = new ADXRS450_Gyro(${gyroport});
+    gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
+    % elif gyro == "AnalogGyro":
+    Gyro gyro = new AnalogGyro(${gyroport});
     gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
     % elif gyro == "NavX":
     AHRS navx = new AHRS(${gyroport});

--- a/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
@@ -15,13 +15,13 @@
     "gearing": 1,
     # Wheel diameter (in units of your choice - will dictate units of analysis)
     "wheelDiameter": 0.333,
-    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", or "None")
+    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", "AnalogGyro", or "None")
     "gyroType": "None",
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
-    # "0" (Pigeon CAN ID),
+    # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",

--- a/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
@@ -15,6 +15,8 @@ import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.interfaces.Gyro;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 
@@ -96,6 +98,9 @@ public class Robot extends TimedRobot {
     // must be negated because getAngle returns a clockwise positive angle
     % if gyro == "ADXRS450":
     Gyro gyro = new ADXRS450_Gyro(${gyroport});
+    gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
+    % elif gyro == "AnalogGyro":
+    Gyro gyro = new AnalogGyro(${gyroport});
     gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
     % elif gyro == "NavX":
     AHRS navx = new AHRS(${gyroport});

--- a/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
@@ -33,13 +33,13 @@
     "leftEncoderInverted": False,
     # Whether the right encoder is inverted:
     "rightEncoderInverted": False,
-    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", or "None")
+    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", "AnalogGyro", or "None")
     "gyroType": "None",
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
-    # "0" (Pigeon CAN ID),
+    # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",

--- a/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
@@ -21,6 +21,8 @@ import com.revrobotics.EncoderType;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.interfaces.Gyro;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 
@@ -113,6 +115,9 @@ public class Robot extends TimedRobot {
     // must be negated because getAngle returns a clockwise positive angle
     % if gyro == "ADXRS450":
     Gyro gyro = new ADXRS450_Gyro(${gyroport});
+    gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
+    % elif gyro == "AnalogGyro":
+    Gyro gyro = new AnalogGyro(${gyroport});
     gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
     % elif gyro == "NavX":
     AHRS navx = new AHRS(${gyroport});

--- a/frc_characterization/drive_characterization/templates/SparkMAX/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/SparkMAX/robotconfig.py
@@ -24,13 +24,13 @@
     "gearing": 1,
     # Wheel diameter (in units of your choice - will dictate units of analysis)
     "wheelDiameter": 0.333,
-    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", or "None")
+    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", "AnalogGyro", or "None")
     "gyroType": "None",
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
-    # "0" (Pigeon CAN ID),
+    # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",

--- a/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
@@ -20,6 +20,8 @@ import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.interfaces.Gyro;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 
@@ -123,6 +125,9 @@ public class Robot extends TimedRobot {
     // must be negated because getAngle returns a clockwise positive angle
     % if gyro == "ADXRS450":
     Gyro gyro = new ADXRS450_Gyro(${gyroport});
+    gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
+    % elif gyro == "AnalogGyro":
+    Gyro gyro = new AnalogGyro(${gyroport});
     gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
     % elif gyro == "NavX":
     AHRS navx = new AHRS(${gyroport});

--- a/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
@@ -26,13 +26,13 @@
     "leftEncoderInverted": False,
     # Whether the right encoder is inverted:
     "rightEncoderInverted": False,
-    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", or "None")
+    # Your gyro type (one of "NavX", "Pigeon", "ADXRS450", "AnalogGyro", or "None")
     "gyroType": "None",
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
-    # "0" (Pigeon CAN ID),
+    # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new TalonSRX(3)" (Pigeon on a Talon SRX),
     # "leftSlave" (Pigeon on the left slave Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)


### PR DESCRIPTION
Somehow I missed this one when I grepped the wpilib javadoc for "gyro" to make sure that I didn't miss any gyros to add for the track width PR.