### PR TITLE
Remove and clarify erroneous references to the Talon SRX in comments

### DIFF
--- a/frc_characterization/arm_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/arm_characterization/templates/Neo/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/arm_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/arm_characterization/templates/Neo/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/arm_characterization/templates/SparkMax/Robot.java.mako
+++ b/frc_characterization/arm_characterization/templates/SparkMax/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/arm_characterization/templates/SparkMax/Robot.java.mako
+++ b/frc_characterization/arm_characterization/templates/SparkMax/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/arm_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/arm_characterization/templates/Talon/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/arm_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/arm_characterization/templates/Talon/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
@@ -22,7 +22,7 @@
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
     # "0" (Pigeon CAN ID or AnalogGyro channel),
-    # "new TalonSRX(3)" (Pigeon on a Talon SRX),
+    # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",
 }

--- a/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
@@ -40,7 +40,7 @@
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
     # "0" (Pigeon CAN ID or AnalogGyro channel),
-    # "new TalonSRX(3)" (Pigeon on a Talon SRX),
+    # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",
 }

--- a/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/drive_characterization/templates/SparkMAX/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/SparkMAX/robotconfig.py
@@ -31,7 +31,7 @@
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
     # "0" (Pigeon CAN ID or AnalogGyro channel),
-    # "new TalonSRX(3)" (Pigeon on a Talon SRX),
+    # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",
 }

--- a/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
@@ -33,7 +33,7 @@
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
     # "0" (Pigeon CAN ID or AnalogGyro channel),
-    # "new TalonSRX(3)" (Pigeon on a Talon SRX),
+    # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "leftSlave" (Pigeon on the left slave Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",

--- a/frc_characterization/elevator_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/elevator_characterization/templates/Neo/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/elevator_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/elevator_characterization/templates/Neo/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/elevator_characterization/templates/SparkMax/Robot.java.mako
+++ b/frc_characterization/elevator_characterization/templates/SparkMax/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/elevator_characterization/templates/SparkMax/Robot.java.mako
+++ b/frc_characterization/elevator_characterization/templates/SparkMax/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;

--- a/frc_characterization/elevator_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/elevator_characterization/templates/Talon/Robot.java.mako
@@ -3,9 +3,7 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
- *
- * This program assumes that you are using TalonSRX motor controllers and that
- * the drivetrain encoders are attached to the TalonSRX
+
  */
 
 package dc;

--- a/frc_characterization/elevator_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/elevator_characterization/templates/Talon/Robot.java.mako
@@ -3,7 +3,6 @@
  * the data_logger script to characterize your drivetrain. If you wish to use
  * your actual robot code, you only need to implement the simple logic in the
  * autonomousPeriodic function and change the NetworkTables update rate
-
  */
 
 package dc;


### PR DESCRIPTION
This fixes a couple of comments that said the non-Talon SRX templates assume a Talon SRX. It also clarifies that you need to use `WPI_TalonSRX` if you're using a Pigeon IMU connected to a Talon SRX.

Fixes #73.