### PR TITLE
Add note about using Talon FXes

### DIFF
--- a/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
@@ -2,6 +2,7 @@
     # Class names of motor controllers used.
     # Options:
     # 'WPI_TalonSRX'
+    # 'WPI_TalonFX' (for Falcon 500 motors)
     # 'WPI_VictorSPX'
     # Note: The first motor on each side should always be a TalonSRX, as the
     # VictorSPX does not support encoder connections


### PR DESCRIPTION
Some users were getting confused about how to use Talon FXes with frc-characterization. This adds a note on how that can be done.

Please don't merge before #68—you won't be able to use `WPI_TalonFX` until we have the latest CTRE vendordep.