### PR TITLE
Fix missing import for Pigeon on a Talon with a non-Talon project

### DIFF
--- a/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
@@ -14,6 +14,9 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
+// WPI_Talon* imports are needed in case a user has a Pigeon on a Talon
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;

--- a/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
@@ -12,6 +12,9 @@ import java.util.function.Supplier;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 
+// WPI_Talon* imports are needed in case a user has a Pigeon on a Talon
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;

--- a/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/SparkMAX/Robot.java.mako
@@ -15,6 +15,9 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.CANEncoder;
 import com.revrobotics.EncoderType;
 
+// WPI_Talon* imports are needed in case a user has a Pigeon on a Talon
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;

--- a/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 
 import com.ctre.phoenix.sensors.PigeonIMU;

--- a/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
@@ -4,7 +4,7 @@
     # 'WPI_TalonSRX'
     # 'WPI_TalonFX' (for Falcon 500 motors)
     # 'WPI_VictorSPX'
-    # Note: The first motor on each side should always be a TalonSRX, as the
+    # Note: The first motor on each side should always be a Talon SRX/FX, as the
     # VictorSPX does not support encoder connections
     "rightControllerTypes": ["WPI_TalonSRX", "WPI_TalonSRX"],
     "leftControllerTypes": ["WPI_TalonSRX", "WPI_TalonSRX"],
@@ -35,7 +35,7 @@
     # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
     # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
-    # "leftSlave" (Pigeon on the left slave Talon SRX),
+    # "leftSlave" (Pigeon on the left slave Talon SRX/FX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
     "gyroPort": "",
 }


### PR DESCRIPTION
It occurred to me that you can actually have your Pigeon IMU connected to a Talon when you're using a Neo/PWM drivetrain. The `WPI_Talon*` import was missing from the non-Talon projects, which would be a problem if anyone has the setup I just described. This fixes that.