### PR TITLE
Clarify motor port ordering for the Talon SRX and Spark MAX robotconfigs

### DIFF
--- a/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
@@ -3,7 +3,7 @@
     "leftMotorPorts": [0, 1],
     # Ports for the right-side motors
     "rightMotorPorts": [2, 3],
-    # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
+    # Note: Inversions of the slaves (i.e. any motor *after* the first on
     # each side of the drive) are *with respect to their master*.  This is
     # different from the other poject types!
     # Inversions for the left-side motors

--- a/frc_characterization/drive_characterization/templates/SparkMax/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/SparkMax/robotconfig.py
@@ -1,9 +1,10 @@
 {
+    # Note: The first motor in the list of ports should be the one with an encoder
     # Ports for the left-side motors
     "leftMotorPorts": [0, 1],
     # Ports for the right-side motors
     "rightMotorPorts": [2, 3],
-    # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
+    # Note: Inversions of the slaves (i.e. any motor *after* the first on
     # each side of the drive) are *with respect to their master*.  This is
     # different from the other poject types!
     # Inversions for the left-side motors

--- a/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
@@ -8,6 +8,7 @@
     # VictorSPX does not support encoder connections
     "rightControllerTypes": ["WPI_TalonSRX", "WPI_TalonSRX"],
     "leftControllerTypes": ["WPI_TalonSRX", "WPI_TalonSRX"],
+    # Note: The first id in the list of ports should be the one with an encoder
     # Ports for the left-side motors
     "leftMotorPorts": [0, 1],
     # Ports for the right-side motors


### PR DESCRIPTION
A user on the FRC Discord had an issue with this, so it seemed worthwhile to add a note about how you're supposed to order your motor controller ports.