### PR TITLE
Fix drive Simple template generating the wrong number of motor instantiations

### DIFF
--- a/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
@@ -85,7 +85,7 @@ public class Robot extends TimedRobot {
     % endif
     % endfor
 
-    SpeedController[] rightMotors = new SpeedController[${len(lports) - 1}];
+    SpeedController[] rightMotors = new SpeedController[${len(rports) - 1}];
     % for port in rports[1:]:
     rightMotors[${loop.index}] = new ${rcontrollers[loop.index+1]}(${port});
     % if rinverted[loop.index+1]:


### PR DESCRIPTION
This bug would probably never be encountered in the wild because no sane
person would ever have an asymmetrical number of motors on their
drivetrain... But it's a bug nevertheless.