### PR TITLE
Add imports and notes about using the NavX SerialPort.Port.kMXP

### DIFF
--- a/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Neo/Robot.java.mako
@@ -22,6 +22,7 @@ import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
+import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 

--- a/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
@@ -20,7 +20,8 @@
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
-    # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
+    # "SerialPort.Port.kMXP" (MXP Serial port for NavX),
+    # "I2C.Port.kOnboard" (Onboard I2C port for NavX),
     # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)

--- a/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Simple/Robot.java.mako
@@ -20,6 +20,7 @@ import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
+import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 

--- a/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
@@ -38,7 +38,8 @@
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
-    # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
+    # "SerialPort.Port.kMXP" (MXP Serial port for NavX),
+    # "I2C.Port.kOnboard" (Onboard I2C port for NavX),
     # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)

--- a/frc_characterization/drive_characterization/templates/SparkMax/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/SparkMax/Robot.java.mako
@@ -23,6 +23,7 @@ import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
+import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 

--- a/frc_characterization/drive_characterization/templates/SparkMax/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/SparkMax/robotconfig.py
@@ -29,7 +29,8 @@
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
-    # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
+    # "SerialPort.Port.kMXP" (MXP Serial port for NavX),
+    # "I2C.Port.kOnboard" (Onboard I2C port for NavX),
     # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)

--- a/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/drive_characterization/templates/Talon/Robot.java.mako
@@ -20,6 +20,7 @@ import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
+import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 

--- a/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
@@ -32,7 +32,8 @@
     # Whatever you put into the constructor of your gyro
     # Could be:
     # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
-    # "I2C.Port.kOnboard" (Onboard I2C port for NavX)
+    # "SerialPort.Port.kMXP" (MXP Serial port for NavX),
+    # "I2C.Port.kOnboard" (Onboard I2C port for NavX),
     # "0" (Pigeon CAN ID or AnalogGyro channel),
     # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
     # "leftSlave" (Pigeon on the left slave Talon SRX/FX),


### PR DESCRIPTION
Closes #86. Sorry about this. I had missed that you could pass a `SerialPort` to the NavX constructor when I made the track width PR.