### PR TITLE
Fix SimpleMotor default feedback controller sample period

### DIFF
--- a/frc_characterization/simplemotor_characterization/data_analyzer.py
+++ b/frc_characterization/simplemotor_characterization/data_analyzer.py
@@ -66,7 +66,7 @@ class ProgramState:
         self.max_effort.set(3)
 
         self.period = DoubleVar(self.mainGUI)
-        self.period.set(5)
+        self.period.set(0.02)
 
         self.max_controller_output = DoubleVar(self.mainGUI)
         self.max_controller_output.set(12)


### PR DESCRIPTION
It was set to 5s and should be 20ms like the others.