### PR TITLE
Integrate/document TalonFX into non-drivetrain templates

### DIFF
--- a/frc_characterization/arm_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/arm_characterization/templates/Talon/Robot.java.mako
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 
 import edu.wpi.first.networktables.NetworkTableEntry;
@@ -93,8 +94,14 @@ public class Robot extends TimedRobot {
     double encoderConstant = 1;
     % endif
 
-    armMaster.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, PIDIDX,
-                                          10);
+    armMaster.configSelectedFeedbackSensor(
+        % if controllers[0] == "WPI_TalonFX":
+        FeedbackDevice.IntegratedSensor,
+        % else:
+        FeedbackDevice.QuadEncoder,
+        % endif
+        PIDIDX, 10
+    );
     encoderPosition = ()
         -> armMaster.getSelectedSensorPosition(PIDIDX) * encoderConstant +
                OFFSET;

--- a/frc_characterization/arm_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/arm_characterization/templates/Talon/robotconfig.py
@@ -2,8 +2,9 @@
     # Class names of motor controllers used.
     # Options:
     # 'WPI_TalonSRX'
+    # 'WPI_TalonFX'
     # 'WPI_VictorSPX'
-    # Note: The first motor should always be a TalonSRX, as the VictorSPX
+    # Note: The first motor should always be a TalonSRX/FX, as the VictorSPX
     # does not support encoder connections.
     "controllerTypes": ["WPI_TalonSRX"],
     # Ports for the motors

--- a/frc_characterization/elevator_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/elevator_characterization/templates/Talon/Robot.java.mako
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 
 import edu.wpi.first.networktables.NetworkTableEntry;
@@ -84,8 +85,14 @@ public class Robot extends TimedRobot {
     double encoderConstant =
         (1 / ENCODER_EDGES_PER_REV) * PULLEY_DIAMETER * Math.PI;
 
-    elevatorMaster.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, PIDIDX,
-                                          10);
+    elevatorMaster.configSelectedFeedbackSensor(
+        % if controllers[0] == "WPI_TalonFX":
+        FeedbackDevice.IntegratedSensor,
+        % else:
+        FeedbackDevice.QuadEncoder,
+        % endif
+        PIDIDX, 10
+    );
     encoderPosition = ()
         -> elevatorMaster.getSelectedSensorPosition(PIDIDX) * encoderConstant;
     encoderRate =

--- a/frc_characterization/elevator_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/elevator_characterization/templates/Talon/robotconfig.py
@@ -2,8 +2,9 @@
     # Class names of motor controllers used.
     # Options:
     # 'WPI_TalonSRX'
+    # 'WPI_TalonFX'
     # 'WPI_VictorSPX'
-    # Note: The first motor should always be a TalonSRX, as the VictorSPX
+    # Note: The first motor should always be a TalonSRX/FX, as the VictorSPX
     # does not support encoder connections.
     "controllerTypes": ["WPI_TalonSRX"],
     # Ports for the motors

--- a/frc_characterization/simplemotor_characterization/templates/Talon/Robot.java.mako
+++ b/frc_characterization/simplemotor_characterization/templates/Talon/Robot.java.mako
@@ -88,8 +88,14 @@ public class Robot extends TimedRobot {
     double encoderConstant = (1 / ENCODER_EDGES_PER_REV) * 1;
     % endif
 
-    master.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder,
-                                                PIDIDX, 10);
+    master.configSelectedFeedbackSensor(
+        % if controllers[0] == "WPI_TalonFX":
+        FeedbackDevice.IntegratedSensor,
+        % else:
+        FeedbackDevice.QuadEncoder,
+        % endif
+        PIDIDX, 10
+    );
     encoderPosition = ()
         -> master.getSelectedSensorPosition(PIDIDX) * encoderConstant;
     encoderRate = ()


### PR DESCRIPTION
There were some missing TalonFX imports and wrong encoder configuration in non-drivetrain templates.