### PR TITLE
Lock Windows numpy version to 1.19.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
+        "numpy==1.19.3;platform_system=='Windows'",
         "control",
         "frccontrol",
         "matplotlib",


### PR DESCRIPTION
See https://stackoverflow.com/a/64661876. Numpy 1.19.3 used  a different
version of OpenBLAS to work around a Windows bug
(https://developercommunity.visualstudio.com/content/problem/1207405/fmod-after-an-update-to-windows-2004-is-causing-a.html).
This change broke Linux, so it was reverted in 1.19.4. Therefore, we
install 1.19.3 for Windows and the latest version for all other
platforms.

Note that this Windows bug only affects 64-bit versions of Python.