### PR TITLE
Fix small bugs introduced in refactor

### DIFF
--- a/frc_characterization/logger_analyzer/data_analyzer.py
+++ b/frc_characterization/logger_analyzer/data_analyzer.py
@@ -587,8 +587,6 @@ class Analyzer:
             "Backward Left",
             "Backward Right",
             "Backward Combined",
-            "Left Combined",
-            "Right Combined",
         }
         directions = {"Combined", "Forward", "Backward"}
         dirMenu = OptionMenu(topFrame, self.subset, *sorted(directions))
@@ -996,7 +994,7 @@ class Analyzer:
                 return False
         return True
 
-    def prepare_dataDrive(self, data, window):
+    def prepare_data_drivetrain(self, data, window):
         """
         Firstly, data should be 'trimmed' to exclude any data points at which the
         robot was not being commanded to do anything.
@@ -1086,9 +1084,9 @@ class Analyzer:
                 np.concatenate((sb_l, sb_r), axis=1),
                 np.concatenate((fb_l, fb_r), axis=1),
             ],
-            "Combined": [
+            "All Combined": [
                 np.concatenate((sf_l, sb_l, sf_r, sb_r), axis=1),
-                np.concatentate((ff_l, fb_l, ff_r, ff_r), axis=1),
+                np.concatenate((ff_l, fb_l, ff_r, ff_r), axis=1),
             ],
             "Valid": self.is_valid(sf_l, sb_l, ff_l, fb_l, sf_r, sb_r, ff_r, fb_r),
         }
@@ -1131,7 +1129,7 @@ class Analyzer:
 
         test = Tests(self.test.get())
         if test == Tests.DRIVETRAIN:
-            return self.prepare_dataDrive(data, window)
+            return self.prepare_data_drivetrain(data, window)
         else:
             # Ensure voltage points in same direction as velocity
             for x in JSON_DATA_KEYS:

--- a/frc_characterization/logger_analyzer/templates/Robot.java.mako
+++ b/frc_characterization/logger_analyzer/templates/Robot.java.mako
@@ -320,23 +320,23 @@ public class Robot extends TimedRobot {
     leaderMotor = new SpeedControllerGroup(leftMotor, leftMotorControllers);
       % endif
     % endif
+
     //
     // Configure gyro
     //
 
-    % if gyroType:
-      // Note that the angle from the NavX and all implementors of wpilib Gyro
-      // must be negated because getAngle returns a clockwise positive angle
-      % if gyroType == "ADXRS450":
+    // Note that the angle from the NavX and all implementors of WPILib Gyro
+    // must be negated because getAngle returns a clockwise positive angle
+    % if gyroType == "ADXRS450":
     Gyro gyro = new ADXRS450_Gyro(${gyroPort});
     gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
-      % elif gyroType == "AnalogGyro":
+    % elif gyroType == "AnalogGyro":
     Gyro gyro = new AnalogGyro(${gyroPort});
     gyroAngleRadians = () -> -1 * Math.toRadians(gyro.getAngle());
-      % elif gyroType == "NavX":
+    % elif gyroType == "NavX":
     AHRS navx = new AHRS(${gyroPort});
     gyroAngleRadians = () -> -1 * Math.toRadians(navx.getAngle());
-      % elif gyroType == "Pigeon":
+    % elif gyroType == "Pigeon":
     // Uncomment for Pigeon
     PigeonIMU pigeon = new PigeonIMU(${gyroPort});
     gyroAngleRadians = () -> {
@@ -345,10 +345,10 @@ public class Robot extends TimedRobot {
       pigeon.getAccumGyro(xyz);
       return Math.toRadians(xyz[2]);
     };
-      % else:
+    % else:
     gyroAngleRadians = () -> 0.0;
-      % endif
     % endif
+
     // Set the update rate instead of using flush because of a ntcore bug
     // -> probably don't want to do this on a robot in competition
     NetworkTableInstance.getDefault().setUpdateRate(0.010);


### PR DESCRIPTION
 - Fixes the `gyroSupplier` getting left as null if no gyro is selected.
 - Fixes crashes when "All Combined", "Left Combined", or "Right Combined" are selected.
 - Fixes some small naming inconsistencies.