### PR TITLE
Fixes IsADirectoryError from importlib.resources.path()

### DIFF
--- a/frc_characterization/logger_analyzer/__init__.py
+++ b/frc_characterization/logger_analyzer/__init__.py
@@ -1,16 +1,34 @@
 from mako.template import Template
 
 import os
-import importlib.resources as resources
+from importlib import import_module
+import pathlib
+import zipfile
+
+
+# TODO: Replace with Python 3.9's importlib.resources.files() when it becomes min version
+def files(package):
+    spec = import_module(package).__spec__
+    if spec.submodule_search_locations is None:
+        raise TypeError("{!r} is not a package".format(package))
+
+    package_directory = pathlib.Path(spec.origin).parent
+    try:
+        archive_path = spec.loader.archive
+        rel_path = package_directory.relative_to(archive_path)
+        return zipfile.Path(archive_path, str(rel_path) + "/")
+    except Exception:
+        pass
+    return package_directory
 
 
 def gen_robot_code(config):
-    with resources.path(__name__, "templates") as path:
-        with open(os.path.join(path, "Robot.java.mako"), "r") as template:
-            return Template(template.read()).render(**config)
+    path = files(__name__).joinpath("templates")
+    with open(os.path.join(path, "Robot.java.mako"), "r") as template:
+        return Template(template.read()).render(**config)
 
 
 def gen_build_gradle(team):
-    with resources.path(__name__, "templates") as path:
-        with open(os.path.join(path, "build.gradle.mako"), "r") as template:
-            return Template(template.read()).render(team=team)
+    path = files(__name__).joinpath("templates")
+    with open(os.path.join(path, "build.gradle.mako"), "r") as template:
+        return Template(template.read()).render(team=team)

--- a/frc_characterization/newproject/__init__.py
+++ b/frc_characterization/newproject/__init__.py
@@ -116,6 +116,12 @@ class NewProjectGUI:
             with open(self.config_path.get(), "w+") as config:
                 config.write(self.config.get())
 
+        def updateTemplatePath(*args):
+            nonlocal templatePath
+            with resources.path(mech, "templates") as path:
+                templatePath = path
+            getDefaultConfig()
+
         def updateConfigPath(*args):
             configEntry.configure(state="normal")
             self.config_path.set(
@@ -124,9 +130,11 @@ class NewProjectGUI:
             configEntry.configure(state="readonly")
 
         def getDefaultConfig(*args):
-            with resources.open_text(
-                "frc_characterization.logger_analyzer.templates.configs",
-                f"{self.control_type.get().lower()}config.py",
+            with open(
+                os.path.join(
+                    templatePath, f"configs/{self.control_type.get().lower()}config.py"
+                ),
+                "r",
             ) as config:
                 self.config.set(config.read())
 
@@ -376,6 +384,9 @@ class NewProjectGUI:
 
         def isRotation(units):
             return Units(units) in (Units.ROTATIONS, Units.RADIANS, Units.DEGREES)
+
+        templatePath = None
+        updateTemplatePath()
 
         getDefaultConfig()
 


### PR DESCRIPTION
... by replacing it with a method that takes a directory not a filepath.

* Reimplements importlib.resources.files() locally because it does not exist in
versions prior to Python 3.9.
* Should properly fix #158 in all the locations it occurs.
* This reverts commit 76cd65b777eb2d3eb151d923dee7c297fb552514