### PR TITLE
Comments Pertaining to Falcon500, Wording in robot.java

### DIFF
--- a/frc_characterization/logger_analyzer/templates/Robot.java.mako
+++ b/frc_characterization/logger_analyzer/templates/Robot.java.mako
@@ -56,9 +56,9 @@ import java.util.ArrayList;
 public class Robot extends TimedRobot {
 
   % if controlType == "SparkMax":
-  static private int ENCODER_EDGES_PER_REV = ${encoderEPR} / 4;
+  static private int ENCODER_COUNTS_PER_REV = ${encoderEPR} / 4;
   % else:
-  static private double ENCODER_EDGES_PER_REV = ${encoderEPR} / 4.;
+  static private double ENCODER_COUNTS_PER_REV = ${encoderEPR} / 4.;
   % endif
   static private int PIDIDX = 0;
   static private int ENCODER_EPR = ${encoderEPR};
@@ -67,7 +67,7 @@ public class Robot extends TimedRobot {
   % if controlType == "SparkMax":
   private double encoderConstant = (1 / GEARING);
   % else:
-  private double encoderConstant = (1 / GEARING) * (1 / ENCODER_EDGES_PER_REV);
+  private double encoderConstant = (1 / GEARING) * (1 / ENCODER_COUNTS_PER_REV);
   % endif
 
   Joystick stick;
@@ -156,10 +156,10 @@ public class Robot extends TimedRobot {
           % if not brushed:
       CANEncoder encoder = motor.getEncoder();
           % else:
-      CANEncoder encoder = motor.getEncoder(EncoderType.kQuadrature, ENCODER_EDGES_PER_REV);
+      CANEncoder encoder = motor.getEncoder(EncoderType.kQuadrature, ENCODER_COUNTS_PER_REV);
           % endif
         % else:
-      CANEncoder encoder = motor.getAlternateEncoder(AlternateEncoderType.kQuadrature, ENCODER_EDGES_PER_REV);
+      CANEncoder encoder = motor.getAlternateEncoder(AlternateEncoderType.kQuadrature, ENCODER_COUNTS_PER_REV);
         % endif
       % endif
     % endif

--- a/frc_characterization/logger_analyzer/templates/configs/ctreconfig.py
+++ b/frc_characterization/logger_analyzer/templates/configs/ctreconfig.py
@@ -19,6 +19,7 @@
     "rightMotorsInverted": [],
     # Encoder edges-per-revolution (*NOT* cycles per revolution!)
     # For the CTRE Mag Encoder, use 16384 (4 * 4096 = 16384)
+    # For the Falcon 500 Integrated Encoder, use 8192 (4 * 2048 = 8192)
     "encoderEPR": 16384,
     # Gearing accounts for the gearing between the encoder and the output shaft
     "gearing": 1,


### PR DESCRIPTION
Working on this for my Falcon500 powered gearbox, I was getting confused due to the differences between the Falcon500 motor and the other encoders within robotics. The Falcon500 is not a quadrature encoder, so its CPR = its EPR. Due to this, if you put the value of 2048 into the software for EPR, the code would end up dividing it by 4, causing an bug when running the program. I added a comment into the config that will tell the user what value to use for the Falcon 500s. Also, while looking into robot.java, I realized that a variable that to my knowledge is holding the value of the CPR was named EPR, so I changed the name of it as well.

This is my first time putting in a PR to a public Repo, so please let me know if theres anything I can change to improve this!

Joe A, Programmer for FRC 4567