### PR TITLE
Replace ast.literal_eval with compile then eval

### DIFF
--- a/frc_characterization/newproject/__init__.py
+++ b/frc_characterization/newproject/__init__.py
@@ -7,7 +7,6 @@
 # odd pattern, but allows none of this code to be duplicated so long as the
 # individual project packages all have the same structure.
 
-import ast
 import os
 import pathlib
 import shutil
@@ -166,7 +165,10 @@ class NewProjectGUI:
                 return
 
         def genProject():
-            config = ast.literal_eval(self.config.get())
+            config = eval(
+                compile(self.config.get(), self.config_path.get(), "eval"),
+                {"__builtins__": {}},
+            )
             config["controlType"] = self.control_type.get()
             if self.control_type.get() == "SparkMax":
                 config["controllerTypes"] = ["CANSparkMax"]


### PR DESCRIPTION
This allows error messages to point to the config source itself.

Alternative to #175 and #182.