### PR TITLE
Added support for PWF Venom motor to Robot Characterization

### DIFF
--- a/frc_characterization/logger_analyzer/templates/Robot.java.mako
+++ b/frc_characterization/logger_analyzer/templates/Robot.java.mako
@@ -26,6 +26,8 @@ import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SPI;
 
+import com.playingwithfusion.CANVenom;
+
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
@@ -147,7 +149,7 @@ public class Robot extends TimedRobot {
           % endif
             PIDIDX, 10
       );    
-      % else:
+      % elif controlType != "Venom":
         % if not useDataPort:
           % if not brushed:
       CANEncoder encoder = motor.getEncoder();
@@ -184,8 +186,13 @@ public class Robot extends TimedRobot {
           -> motor.getSelectedSensorPosition(PIDIDX) * encoderConstant;
         rightEncoderRate = ()
           -> motor.getSelectedSensorVelocity(PIDIDX) * encoderConstant *
-               10;
+               10;          
+          %elif controlType == "Venom":
 
+        rightEncoderPosition = ()
+          -> motor.getPosition();     // Revolutions
+        rightEncoderRate = ()
+          -> motor.getSpeed() / 60.;  // Convert RPM to Rev/second
           % else:
 
             % if brushed or useDataPort:
@@ -218,6 +225,12 @@ public class Robot extends TimedRobot {
           -> motor.getSelectedSensorVelocity(PIDIDX) * encoderConstant *
                10;
         
+          %elif controlType == "Venom":
+
+        leftEncoderPosition = ()
+          -> motor.getPosition();     // Revolutions
+        leftEncoderRate = ()
+          -> motor.getSpeed() / 60.;  // Convert RPM to Rev/second
           % else:
             % if brushed or useDataPort:
         encoder.setInverted(${str(encoderInverted).lower()});

--- a/frc_characterization/logger_analyzer/templates/Robot.java.mako
+++ b/frc_characterization/logger_analyzer/templates/Robot.java.mako
@@ -149,7 +149,7 @@ public class Robot extends TimedRobot {
           % endif
             PIDIDX, 10
       );    
-      % elif controlType != "Venom":
+      % elif controlType == "SparkMax":
         % if not useDataPort:
           % if not brushed:
       CANEncoder encoder = motor.getEncoder();

--- a/frc_characterization/logger_analyzer/templates/configs/pwfconfig.py
+++ b/frc_characterization/logger_analyzer/templates/configs/pwfconfig.py
@@ -1,0 +1,47 @@
+{
+    # CAN device IDs for motors
+    # If doing drive test, treat this as the left side of the drivetrain
+    "motorPorts": [],
+    # Only if you are doing drive (leave empty "[]" if not)
+    "rightMotorPorts": [],
+    # Class names of motor controllers used.
+    # Options:
+    # 'CANVenom'
+    # If doing drive test, treat this as the left side of the drivetrain
+    "controllerTypes": [],
+    # Only if you are doing drive (leave empty "[]" if not)
+    "rightControllerTypes": [],
+    # Set motors to inverted or not
+    # If doing drive test, treat this as the left side of the drivetrain
+    "motorsInverted": [],
+    # Only if you are doing drive (leave empty "[]" if not)
+    "rightMotorsInverted": [],
+    # Encoder edges-per-revolution (*NOT* cycles per revolution!)
+    # encoderEPR is ignored when using the built in Venom encoder
+    "encoderEPR": 1,
+    # Gearing accounts for the gearing between the encoder and the output shaft
+    "gearing": 1,
+    # Encoder ports
+    # If doing drive test, treat this as the left side of the drivetrain
+    # Leave empty "[]" if using the built in Venom encoder
+    "encoderPorts": [],
+    # Only if you are doing drive (leave empty "[]" if not)
+    "rightEncoderPorts": [],
+    # Set to True if encoders need to be inverted
+    # If doing drive test, treat this as the left side of the drivetrain
+    "encoderInverted": False,
+    # Only if you are doing drive (set to False if not needed)
+    "rightEncoderInverted": False,
+    # ** The following is only if you are using a gyro for the DriveTrain test**
+    # Gyro type (one of "NavX", "Pigeon", "ADXRS450", "AnalogGyro", or "None")
+    "gyroType": "None",
+    # Whatever you put into the constructor of your gyro
+    # Could be:
+    # "SPI.Port.kMXP" (MXP SPI port for NavX or ADXRS450),
+    # "SerialPort.Port.kMXP" (MXP Serial port for NavX),
+    # "I2C.Port.kOnboard" (Onboard I2C port for NavX),
+    # "0" (Pigeon CAN ID or AnalogGyro channel),
+    # "new WPI_TalonSRX(3)" (Pigeon on a Talon SRX),
+    # "" (NavX using default SPI, ADXRS450 using onboard CS0, or no gyro)
+    "gyroPort": "",
+}

--- a/frc_characterization/newproject/__init__.py
+++ b/frc_characterization/newproject/__init__.py
@@ -478,7 +478,7 @@ class NewProjectGUI:
         )
 
         controlMenu = OptionMenu(
-            topFrame, self.control_type, *["Simple", "CTRE", "SparkMax"]
+            topFrame, self.control_type, *["Simple", "CTRE", "SparkMax", "Venom"]
         )
         controlMenu.configure(width=25)
         controlMenu.grid(row=2, column=12, sticky="ew")

--- a/frc_characterization/robot/project/vendordeps/playingwithfusion2021.json
+++ b/frc_characterization/robot/project/vendordeps/playingwithfusion2021.json
@@ -1,0 +1,58 @@
+{
+    "fileName": "playingwithfusion2021.json",
+    "name": "PlayingWithFusion",
+    "version": "2021.03.06",
+    "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",
+    "jsonUrl": "https://www.playingwithfusion.com/frc/playingwithfusion2021.json",
+    "mavenUrls": [
+        "https://www.playingwithfusion.com/frc/maven/"
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-java",
+            "version": "2021.03.06"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-driver",
+            "version": "2021.03.06",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-cpp",
+            "version": "2021.03.06",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "libName": "PlayingWithFusion",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64"
+            ]
+        },
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-driver",
+            "version": "2021.03.06",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "libName": "PlayingWithFusionDriver",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
 - Added PWF Config option to the UI.
 - Added Venom specific config.py.   (Basically the same as simple, but with Venom specific comments)
 - Robot.Java.Mako to support CANVenom class and to use built-in Venom encoder